### PR TITLE
Adopted typst latest release naming conventions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
         uses: actions/checkout@v3
         
       - name: Compile basic Typst document 
-        uses:  Jarivanbakel/typst-action@v2
+        uses:  Jarivanbakel/typst-action@v3
         with:
           input_files: test/doc.typ
 
       - name: Compile multiple Typst documents
-        uses:  Jarivanbakel/typst-action@v2
+        uses:  Jarivanbakel/typst-action@v3
         with:
           input_files: |
             test/doc.typ 
@@ -30,7 +30,7 @@ jobs:
             test/subdir2/doc.typ
 
       - name: Compile basic Typst document 
-        uses:  Jarivanbakel/typst-action@v2
+        uses:  Jarivanbakel/typst-action@v3
         with:
           working_directory: test
           input_files: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A cross-OS GitHub Action to compile Typst documents
 
 The Typst file(s) to be compiled. This input is required. You can also pass multiple files as a multi-line string to compile multiple documents. For example:
 ```yaml
-- uses:  Jarivanbakel/typst-action@v2
+- uses:  Jarivanbakel/typst-action@v3
   with:
     input_files: |
       file1.typ 
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses:  Jarivanbakel/typst-action@v2
+      - uses:  Jarivanbakel/typst-action@v3
         with:
           input_files: file1.typ
       - name: Upload PDF file

--- a/action.yml
+++ b/action.yml
@@ -17,17 +17,16 @@ runs:
       shell: bash
       id: determine_os
       run: |
+        archive_extension=".tar.xz"
         if [ "$RUNNER_OS" == 'Linux' ]; 
         then
-             binary_type="x86_64-unknown-linux-gnu"
-             archive_extension=".tar.xz"
+             binary_type="x86_64-unknown-linux-musl"
         elif [ "$RUNNER_OS" == 'Windows' ]; 
         then
              binary_type="x86_64-pc-windows-msvc"
              archive_extension=".zip"
         else 
              binary_type="x86_64-apple-darwin"
-             archive_extension=".tar.xz"
         fi
         
         echo "binary_type=$binary_type" >> $GITHUB_OUTPUT
@@ -66,7 +65,7 @@ runs:
       shell: bash
       if: steps.binary_exists.outputs.exists != 'true'
       run: |
-        echo Running on $RUNNER_OS extracting $binary_type$archive_extension
+        echo Running on $RUNNER_OS extracting ${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}
 
         if [ "$RUNNER_OS" == 'Windows' ]; 
         then
@@ -76,8 +75,8 @@ runs:
         fi
         
         echo "$PWD"
-        echo "$PWD/typst-x86_64-${{ steps.determine_os.outputs.binary_type }}"
-        echo "$PWD/typst-x86_64-${{ steps.determine_os.outputs.binary_type }}" >> $GITHUB_PATH
+        echo "$PWD/typst-${{ steps.determine_os.outputs.binary_type }}"
+        echo "$PWD/typst-${{ steps.determine_os.outputs.binary_type }}" >> $GITHUB_PATH
         
     - name: Compile Typst documents
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -65,13 +65,13 @@ runs:
       shell: bash
       if: steps.binary_exists.outputs.exists != 'true'
       run: |
-        echo Running on $RUNNER_OS extracting ${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}
+        echo Running on $RUNNER_OS extracting typst-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}
 
         if [ "$RUNNER_OS" == 'Windows' ]; 
         then
             7z x "typst-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
         else
-            tar zxvf "typst-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
+            tar xf "typst-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
         fi
         
         echo "$PWD"

--- a/action.yml
+++ b/action.yml
@@ -19,14 +19,14 @@ runs:
       run: |
         if [ "$RUNNER_OS" == 'Linux' ]; 
         then
-             binary_type="unknown-linux-gnu"
+             binary_type="x86_64-unknown-linux-gnu"
              archive_extension=".tar.gz"
         elif [ "$RUNNER_OS" == 'Windows' ]; 
         then
-             binary_type="pc-windows-msvc"
+             binary_type="x86_64-pc-windows-msvc"
              archive_extension=".zip"
         else 
-             binary_type="apple-darwin"
+             binary_type="x86_64-apple-darwin"
              archive_extension=".tar.gz"
         fi
         
@@ -37,7 +37,7 @@ runs:
       shell: bash
       id: binary_exists
       run: |
-        if [ -d "typst-x86_64-${{ steps.determine_os.outputs.binary_type }}" ]; then
+        if [ -d "typst-${{ steps.determine_os.outputs.binary_type }}" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
         else
             echo "exists=false" >> $GITHUB_OUTPUT
@@ -70,9 +70,9 @@ runs:
 
         if [ "$RUNNER_OS" == 'Windows' ]; 
         then
-            7z x "typst-x86_64-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
+            7z x "typst-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
         else
-            tar zxvf "typst-x86_64-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
+            tar zxvf "typst-${{ steps.determine_os.outputs.binary_type }}${{ steps.determine_os.outputs.archive_extension }}"
         fi
         
         echo "$PWD"

--- a/action.yml
+++ b/action.yml
@@ -20,14 +20,14 @@ runs:
         if [ "$RUNNER_OS" == 'Linux' ]; 
         then
              binary_type="x86_64-unknown-linux-gnu"
-             archive_extension=".tar.gz"
+             archive_extension=".tar.xz"
         elif [ "$RUNNER_OS" == 'Windows' ]; 
         then
              binary_type="x86_64-pc-windows-msvc"
              archive_extension=".zip"
         else 
              binary_type="x86_64-apple-darwin"
-             archive_extension=".tar.gz"
+             archive_extension=".tar.xz"
         fi
         
         echo "binary_type=$binary_type" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Typst added support for more distributions which means the release naming convention changed slightly:
| Before | After |
|----|----|
| typst-x86_64-unknown-linux-gnu.tar.gz  | typst-x86_64-unknown-linux-<ins>musl.tar.xz</ins><br>typst-aarch64-unknown-linux-musl.tar.xz<br>typst-armv7-unknown-linux-musleabi.tar.xz<br>typst-riscv64gc-unknown-linux-gnu.tar.xz | 
| typst-x86_64-apple-darwin.tar.gz | typst-x86_64-apple-darwin<ins>.tar.xz</ins><br>typst-aarch64-apple-darwin.tar.xz  |
|  typst-x86_64-pc-windows-msvc.zip  | typst-aarch64-pc-windows-msvc.zip<br>typst-x86_64-pc-windows-msvc.zip |

The action still uses `x86_64` on the runners but some clarification was needed because `jq` selected the first one that contained, for example, `unknown-linux-gnu` which was the `riscv64gc` distribution. It was made more specific so it always chooses `x86_64` platform.

The archive format also changed slightly; it now uses `tar.xz` instead of `tar.gz`. On top of that the `tar` command was simplified by removing the `z` and `v` flags, removing the need for an archive to be in gzip format and to turn off verbose logging respectively.